### PR TITLE
v1.0.9

### DIFF
--- a/dist/minicrop.esm.js
+++ b/dist/minicrop.esm.js
@@ -227,15 +227,15 @@ var Events = function () {
       var pointers = event.targetTouches || event.changedTouches || [event];
       if (pointers.length > 1) {
         this.pointerOffset = this.getPointerDistance(pointers);
-
-        return;
       }
 
       this.minicrop.editing(CLASS_MOVING);
 
-      var pointer = pointers[0];
-      this.startOffset.x = pointer['clientX'] - offset.x;
-      this.startOffset.y = pointer['clientY'] - offset.y;
+      var center = this.getPointersCenter(pointers);
+      this.startOffset = {
+        x: center.x - offset.x,
+        y: center.y - offset.y
+      };
     }
   }, {
     key: 'dragMove',
@@ -249,8 +249,6 @@ var Events = function () {
       var pointers = event.targetTouches || event.changedTouches || [event];
       if (pointers.length > 1) {
         this.pinch(pointers);
-
-        return;
       }
 
       if (!this.minicrop.moving) {
@@ -259,9 +257,10 @@ var Events = function () {
 
       var offset = this.minicrop.offset;
 
-      var pointer = pointers[0];
-      offset.x = pointer['clientX'] - this.startOffset.x;
-      offset.y = pointer['clientY'] - this.startOffset.y;
+
+      var center = this.getPointersCenter(pointers);
+      offset.x = center.x - this.startOffset.x;
+      offset.y = center.y - this.startOffset.y;
 
       this.minicrop.position();
     }
@@ -277,19 +276,22 @@ var Events = function () {
 
   }, {
     key: 'pinch',
-    value: function pinch(pointers, scale, center) {
-      scale = scale || this.getPointerDistance(pointers);
-      center = center || this.getPointersCenter(pointers);
+    value: function pinch(pointers) {
+      var center = this.getPointersCenter(pointers, this.minicrop.image);
+      var scale = this.getPointerDistance(pointers);
+      var change = -1 * (scale - this.pointerOffset) * 0.25;
 
       var zoomEvent = new CustomEvent("zoom");
-      zoomEvent.deltaY = -1 * (scale - this.pointerOffset);
+      zoomEvent.deltaY = change;
+      zoomEvent.offsetX = center.x;
+      zoomEvent.offsetY = center.y;
 
-      this.zoom(zoomEvent, center);
+      this.zoom(zoomEvent);
       this.pointerOffset = scale;
     }
   }, {
     key: 'zoom',
-    value: function zoom(event, center) {
+    value: function zoom(event) {
       var _this3 = this;
 
       event.preventDefault();
@@ -309,12 +311,13 @@ var Events = function () {
         smoothing /= 3;
       }
 
-      if (!center) {
-        center = { x: event.offsetX, y: event.offsetY };
-      }
-
       var delta = direction * step / smoothing;
+      var center = { x: event.offsetX, y: event.offsetY };
       this.minicrop.zoom(delta, center);
+
+      // Make sure that dragging while zooming stays accurate
+      this.startOffset.x *= 1 + delta;
+      this.startOffset.y *= 1 + delta;
 
       if (this.editingTimeout) {
         clearTimeout(this.editingTimeout);
@@ -330,34 +333,36 @@ var Events = function () {
   }, {
     key: 'getPointerDistance',
     value: function getPointerDistance(pointers) {
-      var _pointers$ = pointers[0],
-          x1 = _pointers$.clientX,
-          y1 = _pointers$.clientY;
-      var _pointers$2 = pointers[1],
-          x2 = _pointers$2.clientX,
-          y2 = _pointers$2.clientY;
+      var _Array$from$shift = Array.from(pointers).shift(),
+          x1 = _Array$from$shift.clientX,
+          y1 = _Array$from$shift.clientY;
 
+      var _Array$from$pop = Array.from(pointers).pop(),
+          x2 = _Array$from$pop.clientX,
+          y2 = _Array$from$pop.clientY;
 
       var distance = Math.sqrt(Math.pow(x2 - x1, 2) + Math.pow(y2 - y1, 2));
       return distance * 2;
     }
   }, {
     key: 'getPointersCenter',
-    value: function getPointersCenter(pointers) {
-      var image = this.minicrop.image;
-
-
+    value: function getPointersCenter(pointers, element) {
       var x = 0;
       var y = 0;
       var count = 0;
 
       Array.from(pointers).forEach(function (pointer) {
-        var _Constrain$coordinate = Constrain.coordinates(pointer, image),
-            clientX = _Constrain$coordinate.clientX,
-            clientY = _Constrain$coordinate.clientY;
+        var center = {
+          clientX: pointer.clientX,
+          clientY: pointer.clientY
+        };
 
-        x += clientX;
-        y += clientY;
+        if (element) {
+          center = Constrain.coordinates(pointer, element);
+        }
+
+        x += center.clientX;
+        y += center.clientY;
         count += 1;
       });
 

--- a/dist/minicrop.esm.js
+++ b/dist/minicrop.esm.js
@@ -10,9 +10,9 @@ var ACTION_CLASSES = [CLASS_MOVING, CLASS_ZOOMING];
 var EVENT_CROP = 'crop';
 var EVENT_ZOOM = 'zoom';
 
-var EVENT_POINTER_DOWN = 'touchstart mousedown';
-var EVENT_POINTER_MOVE = 'touchmove mousemove';
-var EVENT_POINTER_UP = 'touchend touchcancel mouseup mouseout';
+var EVENT_POINTER_DOWN = 'pointerdown touchstart mousedown';
+var EVENT_POINTER_MOVE = 'pointermove touchmove mousemove';
+var EVENT_POINTER_UP = 'pointerup pointercancel touchend touchcancel mouseup mouseout';
 var EVENT_READY = 'ready';
 var EVENT_RESIZE = 'resize';
 var EVENT_WHEEL = 'wheel';

--- a/dist/minicrop.js
+++ b/dist/minicrop.js
@@ -16,9 +16,9 @@
   var EVENT_CROP = 'crop';
   var EVENT_ZOOM = 'zoom';
 
-  var EVENT_POINTER_DOWN = 'touchstart mousedown';
-  var EVENT_POINTER_MOVE = 'touchmove mousemove';
-  var EVENT_POINTER_UP = 'touchend touchcancel mouseup mouseout';
+  var EVENT_POINTER_DOWN = 'pointerdown touchstart mousedown';
+  var EVENT_POINTER_MOVE = 'pointermove touchmove mousemove';
+  var EVENT_POINTER_UP = 'pointerup pointercancel touchend touchcancel mouseup mouseout';
   var EVENT_READY = 'ready';
   var EVENT_RESIZE = 'resize';
   var EVENT_WHEEL = 'wheel';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minicrop",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "main": "dist/minicrop.js",
   "module": "dist/minicrop.esm.js",
   "author": "Derek Lucas <d@derekplucas.com>",

--- a/src/constants.js
+++ b/src/constants.js
@@ -13,9 +13,9 @@ export const ACTION_CLASSES = [CLASS_MOVING, CLASS_ZOOMING]
 export const EVENT_CROP = 'crop'
 export const EVENT_ZOOM = 'zoom'
 
-export const EVENT_POINTER_DOWN = 'touchstart mousedown'
-export const EVENT_POINTER_MOVE = 'touchmove mousemove'
-export const EVENT_POINTER_UP   = 'touchend touchcancel mouseup mouseout'
+export const EVENT_POINTER_DOWN = 'pointerdown touchstart mousedown'
+export const EVENT_POINTER_MOVE = 'pointermove touchmove mousemove'
+export const EVENT_POINTER_UP   = 'pointerup pointercancel touchend touchcancel mouseup mouseout'
 export const EVENT_READY = 'ready'
 export const EVENT_RESIZE = 'resize'
 export const EVENT_WHEEL = 'wheel'

--- a/src/events.js
+++ b/src/events.js
@@ -56,8 +56,6 @@ class Events {
     let pointers = (event.targetTouches || event.changedTouches || [event])
     if (pointers.length > 1) {
       this.pointerOffset = this.getPointerDistance(pointers)
-
-      return
     }
 
     this.minicrop.editing(CLASS_MOVING)
@@ -79,8 +77,6 @@ class Events {
     let pointers = (event.targetTouches || event.changedTouches || [event])
     if (pointers.length > 1) {
       this.pinch(pointers)
-
-      return
     }
 
     if (!this.minicrop.moving) {
@@ -105,11 +101,12 @@ class Events {
   // Zooming
 
   pinch(pointers) {
-    let scale = this.getPointerDistance(pointers)
     let center = this.getPointersCenter(pointers, this.minicrop.image)
+    let scale = this.getPointerDistance(pointers)
+    let change = -1 * (scale - this.pointerOffset) * 0.25
 
     let zoomEvent = new CustomEvent("zoom")
-    zoomEvent.deltaY = -1 * (scale - this.pointerOffset) * 1.5
+    zoomEvent.deltaY = change
     zoomEvent.offsetX = center.x
     zoomEvent.offsetY = center.y
 
@@ -138,6 +135,10 @@ class Events {
     let delta = direction * step / smoothing
     let center = { x: event.offsetX, y: event.offsetY }
     this.minicrop.zoom(delta, center)
+
+    // Make sure that dragging while zooming stays accurate
+    this.startOffset.x *= (1 + delta)
+    this.startOffset.y *= (1 + delta)
 
     if (this.editingTimeout) {
       clearTimeout(this.editingTimeout)


### PR DESCRIPTION
- Add pointer events to try to support pinch zooming on edge
- Drag while pinch zooming with multitouch

It seems this doesn't apply in Firefox or Chrome since those are actually emulating mouse wheels.
Safari doesn't support touch events, instead offering `GestureEvent`s, that don't have touch lists. Eventually we could support mapping Safari's `scale` to the way we do zooming, but we'll have to reconcile that with the way we handle `PointerEvent`s in Mobile Safari.